### PR TITLE
explicitly specify esprima dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "devDependencies" : {
         "tape" : "~1.0.4"
     },
+    "dependencies" : {
+        "esprima" : "*"
+    },
     "engines" : {
         "node" : ">=0.4.0"
     },


### PR DESCRIPTION
You still need to specify bundleDependencies in dependencies, or npm shrinkwrap will fail.  Try making a silly project with just falafel in package.json, npm install, and npm shrinkwrap.  It will fail with an extraneous dependency error for esprima.  This issue effectively makes it impossible to use falafel in any project that uses shrinkwrapping.