### PR TITLE
Make falafel play nice with `npm shrinkwrap`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "scripts" : {
         "test" : "tape test/*.js"
     },
+    "dependencies": {
+        "esprima": "1.1.0-dev"
+    },
     "bundledDependencies" : [ "esprima" ],
     "devDependencies" : {
         "tape" : "~1.0.4"


### PR DESCRIPTION
Because falafel bundles a dependency on esprima but doesn't declare it, I get an error every time I try to `npm shrinkwrap`. I also get warnings at other times about the extraneous esprima. This fixes that.

Fixes #28