### PR TITLE
Add support for custom parse() implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (src, opts, fn) {
     opts.range = true;
     if (typeof src !== 'string') src = String(src);
     
-    var ast = parse(src, opts);
+    var ast = (opts.parse || parse)(src, opts);
     
     var result = {
         chunks : src.split(''),

--- a/readme.markdown
+++ b/readme.markdown
@@ -125,6 +125,9 @@ expression keywords.
 An `opts.isKeyword(id)` value that is a string will be mapped to existing types.
 The only currently supported string value is `"block"`.
 
+If you prefer to use your own, esprima-compatible parse function instead of
+the bundled one, you can pass that in as `opts.parse()`.
+
 # nodes
 
 Aside from the regular [esprima](http://esprima.org) data, you can also call


### PR DESCRIPTION
This is useful if you want to use falafel with e.g. Facebook's JSX-capable fork of Esprima.
