### PR TITLE
For loop issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,6 @@ module.exports = function (src, opts, fn) {
                 });
             }
             else if (child && typeof child.type === 'string') {
-                insertHelpers(child, node, result.chunks);
                 walk(child, node);
             }
         });

--- a/test/for.js
+++ b/test/for.js
@@ -2,19 +2,20 @@ var falafel = require('../');
 var test = require('tape');
 
 test('for loop', function (t) {
-    t.plan(3);
+    t.plan(4);
     
     var src = '(' + function () {
         var sum = 0;
-        for (var i = 0; i < 10; i++) {
-            sum += i;
-        }
+        if (true)
+            for (var i = 0; i < 10; i++)
+                sum += i;
         return sum;
     } + ')()';
     
     var output = falafel(src, function (node) {
         if (node.type === 'ForStatement') {
             t.equal(node.update.source(), 'i++');
+            t.equal(node.update.type, "UpdateExpression");
             node.update.update('i+=2');
         }
         if (node.type === 'UpdateExpression') {

--- a/test/for.js
+++ b/test/for.js
@@ -2,10 +2,12 @@ var falafel = require('../');
 var test = require('tape');
 
 test('for loop', function (t) {
-    t.plan(4);
+    t.plan(7);
     
     var src = '(' + function () {
         var sum = 0;
+        for (var i = 0; i < 10; i++)
+            sum += i;
         if (true)
             for (var i = 0; i < 10; i++)
                 sum += i;
@@ -24,6 +26,5 @@ test('for loop', function (t) {
     });
     
     var res = Function('return ' + output)();
-    t.equal(res, 2 + 4 + 6 + 8);
-    //t.equal(res, 222 + 4 + 6 + 8);
+    t.equal(res, 2 + 4 + 6 + 8 + 2 + 4 + 6 + 8);
 });


### PR DESCRIPTION
This fixes an issue that was occurring when a `ForStatement` was set as a direct child of another `Statement`. The initial call to `insertHelpers` when the child is not an array caused `update` to be considered a function, so when it was called again, it was not recognizing that `update` was an object. Removing the redundant initial call fixed the issue.