### PR TITLE
Removed reference to esprima and replaced with acorn.

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -73,7 +73,7 @@ All of the `opts` will be passed directly to
 
 # nodes
 
-Aside from the regular [esprima](http://esprima.org) data, you can also call
+Aside from the regular [acorn](https://npmjs.org/package/acorn) data, you can also call
 some inserted methods on nodes.
 
 Aside from updating the current node, you can also reach into sub-nodes to call


### PR DESCRIPTION
Esprima is no longer used and the reference was misleading.

In my case, I was attempting to enable line numbers with { loc : true }, which is supported in esprima but not acorn. See https://github.com/substack/node-falafel/issues/37
