### PR TITLE
add support for passing in a version of acorn to use

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function (src, opts, fn) {
     }
     src = src === undefined ? opts.source : src;
     if (typeof src !== 'string') src = String(src);
+    if (opts.parser) parse = opts.parser.parse;
     var ast = parse(src, opts);
     
     var result = {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "acorn": "^1.0.3"
   },
   "devDependencies": {
+    "acorn-jsx": "^2.0.0",
     "tape": "^4.0.0"
   },
   "engines": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -71,6 +71,18 @@ Instead of passing a `src` you can also use `opts.source`.
 All of the `opts` will be passed directly to
 [acorn](https://npmjs.org/package/acorn).
 
+## custom parser
+
+You may pass in an instance of acorn to the opts as `parser` to use that version instead of the version of acorn packaged with this library.
+
+```js
+var acorn = require('acorn-jsx');
+
+falafel(src, {parser: acorn, plugins: { jsx: true }}, function(node) {
+  // this will parse jsx
+});
+```
+
 # nodes
 
 Aside from the regular [esprima](http://esprima.org) data, you can also call

--- a/test/custom-parser.js
+++ b/test/custom-parser.js
@@ -1,0 +1,33 @@
+var falafel = require('../');
+var acorn = require('acorn-jsx');
+var test = require('tape');
+
+test('custom parser', function (t) {
+
+  var src = '(function() { var a = <div className="test"></div>; })()';
+
+  var nodeTypes = [
+    'Identifier',
+    'JSXIdentifier',
+    'Literal',
+    'JSXAttribute',
+    'JSXIdentifier',
+    'JSXOpeningElement',
+    'JSXIdentifier',
+    'JSXClosingElement',
+    'JSXElement',
+    'VariableDeclarator',
+    'VariableDeclaration',
+    'BlockStatement',
+    'FunctionExpression',
+    'CallExpression',
+    'ExpressionStatement',
+    'Program'
+  ];
+
+  t.plan(nodeTypes.length);
+
+  var output = falafel(src, {parser: acorn, plugins: { jsx: true }}, function(node) {
+    t.equal(node.type, nodeTypes.shift());
+  });
+});

--- a/test/custom-parser.js
+++ b/test/custom-parser.js
@@ -4,10 +4,19 @@ var test = require('tape');
 
 test('custom parser', function (t) {
 
-  var src = '(function() { var a = <div className="test"></div>; })()';
+  var src = '(function() { var f = {a: "b"}; var a = <div {...f} className="test"></div>; })()';
 
   var nodeTypes = [
     'Identifier',
+    'Identifier',
+    'Literal',
+    'Property',
+    'ObjectExpression',
+    'VariableDeclarator',
+    'VariableDeclaration',
+    'Identifier',
+    'Identifier',
+    'JSXSpreadAttribute',
     'JSXIdentifier',
     'Literal',
     'JSXAttribute',
@@ -27,7 +36,7 @@ test('custom parser', function (t) {
 
   t.plan(nodeTypes.length);
 
-  var output = falafel(src, {parser: acorn, plugins: { jsx: true }}, function(node) {
+  var output = falafel(src, {parser: acorn, ecmaVersion: 6, plugins: { jsx: true }}, function(node) {
     t.equal(node.type, nodeTypes.shift());
   });
 });


### PR DESCRIPTION
I was trying to use falafel with a codebase that has some .jsx files, but this lib packages acorn so I couldn't swap it for acorn-jsx.

This PR adds the ability to pass in an instance of acorn to the opts as `parser` to use that version instead of the version of acorn packaged with this library.

```js
var acorn = require('acorn-jsx');

falafel(src, {parser: acorn, plugins: { jsx: true }}, function(node) {
  // this will parse jsx
});
```