### PR TITLE
Fix globules, update acorn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+bundle*
+*.log

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "object-keys": "^1.0.6"
   },
   "devDependencies": {
-    "covert": "^1.1.0",
     "acorn-jsx": "^2.0.0",
+    "covert": "^1.1.0",
+    "glob": "^6.0.4",
     "tape": "^4.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "node --harmony test/bin/run.js test/*.js"
   },
   "dependencies": {
-    "acorn": "^1.0.3",
+    "acorn": "^2.0.0",
     "foreach": "^2.0.5",
     "isarray": "0.0.1",
     "object-keys": "^1.0.6"

--- a/test/bin/run.js
+++ b/test/bin/run.js
@@ -1,5 +1,10 @@
 var path = require('path');
+var glob = require('glob');
 
 for (var i = 2; i < process.argv.length; i++) {
-    require(path.resolve(process.cwd(), process.argv[i]));
+	glob(process.argv[i], function (er, files) {
+		files.forEach(function (file) {
+		    require(path.resolve(process.cwd(), file));
+		});
+	});
 }


### PR DESCRIPTION
Hi @substack!
There are tests, fixed for shells without globs.
Also there is an important update of acorn dep, which is the case of glslify https://github.com/stackgl/glslify/issues/68
Please review and merge