### PR TITLE
Version bump Acorn

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "test": "node --harmony test/bin/run.js test/*.js"
   },
   "dependencies": {
-    "acorn": "^2.0.0",
+    "acorn": "^3.0.0",
     "foreach": "^2.0.5",
     "isarray": "0.0.1",
     "object-keys": "^1.0.6"
   },
   "devDependencies": {
-    "acorn-jsx": "^2.0.0",
+    "acorn-jsx": "^3.0.0",
     "covert": "^1.1.0",
     "glob": "^6.0.4",
     "tape": "^4.0.0"


### PR DESCRIPTION
Old version of Acorn is causing problems with es2015 files. Acorn v3 solves #53 and https://github.com/benbria/aliasify/issues/43. Specifically those that include `import`, `export` and `() => {}` are getting an error that import and export can only be used in node modules.