### PR TITLE
Avoid side effects when using custom parsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ module.exports = function (src, opts, fn) {
     }
     src = src === undefined ? opts.source : src;
     if (typeof src !== 'string') src = String(src);
-    if (opts.parser) parse = opts.parser.parse;
-    var ast = parse(src, opts);
+    var ast = (opts.parser ? opts.parser.parse : parse)(src, opts);
     
     var result = {
         chunks : src.split(''),


### PR DESCRIPTION
Previously when a custom parser was provided, the default parser was updated to be that custom parser, causing all further falafel calls to use the custom parser by default.