### PR TITLE
Update acorn to 7.1.1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "node --harmony test/bin/run.js test/*.js"
   },
   "dependencies": {
-    "acorn": "^5.0.0",
+    "acorn": "^7.1.1",
     "foreach": "^2.0.5",
     "isarray": "0.0.1",
     "object-keys": "^1.0.6"


### PR DESCRIPTION
Fixes following error produced by running `npm audit`
```
  Moderate        Regular Expression Denial of Service                          

  Package         acorn                                                         

  Patched in      >=7.1.1                                                       

  Dependency of   falafel                                        

  Path            falafel > acorn                               

  More info       https://npmjs.com/advisories/1488  
```