### PR TITLE
Allow reusing an external AST 

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (src, opts, fn) {
     src = src === undefined ? opts.source : src;
     if (typeof src !== 'string') src = String(src);
     var parser = opts.parser || acorn;
-    var ast = parser.parse(src, opts);
+    var ast = opts.ast || parser.parse(src, opts);
     
     var result = {
         chunks : src.split(''),

--- a/readme.markdown
+++ b/readme.markdown
@@ -84,6 +84,16 @@ falafel(src, {parser: acorn, plugins: { jsx: true }}, function(node) {
 });
 ```
 
+Or, you can just provide the AST directly as `opts.ast`.
+
+```js
+var acorn = require('acorn');
+var ast = acorn.parse(src);
+falafel(src, {ast: ast}, function(node) {
+    // ...
+});
+```
+
 # nodes
 
 Aside from the regular [acorn](https://npmjs.org/package/acorn) data, you can also call


### PR DESCRIPTION
If the user needs to perform additional processing on the AST using some tool other than falafel, it is useful to just give falafel an already existing AST.

This pull request makes falafel look for an `ast` property in `opts` before invoking the `parser`. Note that providing the source code is still necessary for falafel to work properly.