### PR TITLE
add default option for ecma version

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ module.exports = function (src, opts, fn) {
     src = src === undefined ? opts.source : src;
     if (typeof src !== 'string') src = String(src);
     var parser = opts.parser || acorn;
+    
+    opts.ecmaVersion = opts.ecmaVersion || new Date().getFullYear().toString()
+    
     var ast = parser.parse(src, opts);
     
     var result = {


### PR DESCRIPTION
Acorn 8 warns not providing an ecma version will break in the future. Using current year so its hopefully as maintenance free as possible